### PR TITLE
Support ARM64 architecture when running docker tests

### DIFF
--- a/testing/docker/README.md
+++ b/testing/docker/README.md
@@ -40,6 +40,9 @@ This directory contains Docker configurations for testing go-syspkg across multi
 - **Fedora 39**: DNF testing (implementation in progress)
 - **Alpine Linux**: APK testing (implementation in progress)
 
+**Architecture Support:**
+- **AMD64 (x86_64), ARM64 (aarch64/Apple Silicon)**
+
 ## Usage
 
 ### Run All Container Tests

--- a/testing/docker/almalinux.Dockerfile
+++ b/testing/docker/almalinux.Dockerfile
@@ -1,4 +1,5 @@
 # AlmaLinux test container for go-syspkg (YUM testing)
+
 FROM almalinux:8
 
 # Install build dependencies and YUM
@@ -10,8 +11,14 @@ RUN yum update -y && yum install -y \
     which \
     && yum clean all
 
-# Install Go 1.23.4
-RUN curl -L https://go.dev/dl/go1.23.4.linux-amd64.tar.gz | tar -C /usr/local -xz
+# Install Go using Docker's TARGETARCH ARG for platform detection
+ARG GO_VERSION=1.23.4
+ARG TARGETARCH
+RUN if [ -z "${TARGETARCH}" ]; then \
+        echo "Error: TARGETARCH is not set. Use a BuildKit-enabled builder." >&2; \
+        exit 1; \
+    fi && \
+    curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOROOT="/usr/local/go"
 

--- a/testing/docker/alpine.Dockerfile
+++ b/testing/docker/alpine.Dockerfile
@@ -10,8 +10,15 @@ RUN apk add --no-cache \
     alpine-sdk \
     bash
 
-# Install Go 1.23.4 directly (Alpine package manager has older version)
-RUN curl -L https://go.dev/dl/go1.23.4.linux-amd64.tar.gz | tar -C /usr/local -xz
+# Install Go using Docker's TARGETARCH ARG for platform detection
+ARG GO_VERSION=1.23.4
+ARG TARGETARCH
+SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+RUN if [ -z "${TARGETARCH}" ]; then \
+        echo "Error: TARGETARCH is not set. Use a BuildKit-enabled builder." >&2; \
+        exit 1; \
+    fi && \
+    curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Set working directory

--- a/testing/docker/docker-compose.test.yml
+++ b/testing/docker/docker-compose.test.yml
@@ -48,7 +48,7 @@ services:
         go test -v -tags='unit integration yum' ./manager/yum ./osinfo &&
         echo 'Generating YUM fixtures...' &&
         yum search vim > testing/fixtures/yum/search-vim-rocky8.txt 2>/dev/null || true &&
-        yum info vim > testing/fixtures/yum/info-vim-rocky8.txt 2>/dev/null || true &&
+        yum info vim-enhanced > testing/fixtures/yum/info-vim-rocky8.txt 2>/dev/null || true &&
         yum list --installed > testing/fixtures/yum/list-installed-rocky8.txt 2>/dev/null || true
       "
 
@@ -72,7 +72,7 @@ services:
         go test -v -tags='unit integration yum' ./manager/yum ./osinfo &&
         echo 'Generating YUM fixtures...' &&
         yum search vim > testing/fixtures/yum/search-vim-alma8.txt 2>/dev/null || true &&
-        yum info vim > testing/fixtures/yum/info-vim-alma8.txt 2>/dev/null || true
+        yum info vim-enhanced > testing/fixtures/yum/info-vim-alma8.txt 2>/dev/null || true
       "
 
   # TODO: Enable when DNF support is implemented

--- a/testing/docker/rockylinux.Dockerfile
+++ b/testing/docker/rockylinux.Dockerfile
@@ -10,8 +10,15 @@ RUN yum update -y && yum install -y \
     which \
     && yum clean all
 
-# Install Go 1.23.4
-RUN curl -L https://go.dev/dl/go1.23.4.linux-amd64.tar.gz | tar -C /usr/local -xz
+# Install Go using Docker's TARGETARCH ARG for platform detection
+ARG GO_VERSION=1.23.4
+ARG TARGETARCH
+SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+RUN if [ -z "${TARGETARCH}" ]; then \
+        echo "Error: TARGETARCH is not set. Use a BuildKit-enabled builder." >&2; \
+        exit 1; \
+    fi && \
+    curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOROOT="/usr/local/go"
 

--- a/testing/docker/ubuntu.Dockerfile
+++ b/testing/docker/ubuntu.Dockerfile
@@ -14,8 +14,15 @@ RUN apt-get update && apt-get install -y \
     make \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Go 1.23.4
-RUN curl -L https://go.dev/dl/go1.23.4.linux-amd64.tar.gz | tar -C /usr/local -xz
+# Install Go using Docker's TARGETARCH ARG for platform detection
+ARG GO_VERSION=1.23.4
+ARG TARGETARCH
+SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+RUN if [ -z "${TARGETARCH}" ]; then \
+        echo "Error: TARGETARCH is not set. Use a BuildKit-enabled builder." >&2; \
+        exit 1; \
+    fi && \
+    curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Note: snap requires systemd which doesn't work in standard Docker containers


### PR DESCRIPTION
 This PR adds support for running docker tests on ARM64 architecture.

Closes #3 
